### PR TITLE
Fixed encoding of nonce.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ android {
 (async() => {
     let keybob = await Sodium.crypto_box_keypair()
     let keyalice = await Sodium.crypto_box_keypair()
-    let nonce = await Sodium.randomebytes(Sodium.CRYPTO_SECRETBOX_NONCEBYTES)
+    let nonce = await Sodium.randombytes(Sodium.CRYPTO_SECRETBOX_NONCEBYTES)
     let cipher = await Sodium.crypto_box_easy("I miss you Bob", nonce, keybob.PublicKey, keyalice.SecretKey)
     Sodium.crypto_secretbox_open_easy(cipher, nonce, keyalice.PublicKey, keybob.SecretKey).then(console.log) // /(>///<)\
 
@@ -76,7 +76,7 @@ android {
 ## Provide API
 all api using async
 
-## randomebytes(length:int) return string
+## randombytes(length:int) return string
 //use to random generate nonce, seed, etc.
 * length : output length
 * return : randombytes in hex string format

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ android {
 (async() => {
     let keybob = await Sodium.crypto_box_keypair()
     let keyalice = await Sodium.crypto_box_keypair()
-    let nonce = await Sodium.randombytes(Sodium.CRYPTO_SECRETBOX_NONCEBYTES)
+    let nonce = await Sodium.randombytes(Sodium.CRYPTO_BOX_NONCEBYTES)
     let cipher = await Sodium.crypto_box_easy("I miss you Bob", nonce, keybob.PublicKey, keyalice.SecretKey)
-    Sodium.crypto_secretbox_open_easy(cipher, nonce, keyalice.PublicKey, keybob.SecretKey).then(console.log) // /(>///<)\
+    Sodium.crypto_box_open_easy(cipher, nonce, keyalice.PublicKey, keybob.SecretKey).then(console.log) // /(>///<)\
 
     let keysig = await Sodium.crypto_sign_keypair()
     let sig = await Sodium.crypto_sign_detached("My name is donus.", keysig.SigningKey)
@@ -140,7 +140,7 @@ all api using async
 * cipher : cipher from above api
 * nonce : randome string size CRYPTO_SECRETBOX_NONCEBYTES
 * secretKey : same as above api
-* return : original message for sure! 
+* return : original message for sure!
 ### crypto_auth(input :string, key :string) return string
 https://download.libsodium.org/doc/secret-key_cryptography/secret-key_authentication.html
 ### crypto_auth_verify(mac :string, input :string, key :string) return boolean

--- a/android/src/main/java/com/sodium/SodiumModule.java
+++ b/android/src/main/java/com/sodium/SodiumModule.java
@@ -118,7 +118,7 @@ public class SodiumModule extends ReactContextBaseJavaModule {
         byte[] bpublicKey = toByte(publicKey);
         byte[] bprivateKey = toByte(secretKey);
         byte[] bmessage = message.getBytes();
-        byte[] bnonce = nonce.getBytes();
+        byte[] bnonce = toByte(nonce);
         byte[] cipher = new byte[bmessage.length + CRYPTO_SECRETBOX_MACBYTES];
         sodium().crypto_box_easy(cipher, bmessage, bmessage.length, bnonce, bpublicKey, bprivateKey);
         promise.resolve(toString(cipher));
@@ -129,7 +129,7 @@ public class SodiumModule extends ReactContextBaseJavaModule {
         byte[] bpublicKey = toByte(publicKey);
         byte[] bprivateKey = toByte(secretKey);
         byte[] bciphertext = toByte(ciphertext);
-        byte[] bnonce = nonce.getBytes();
+        byte[] bnonce = toByte(nonce);
         byte[] decipher = new byte[bciphertext.length - CRYPTO_SECRETBOX_MACBYTES];
         sodium().crypto_box_open_easy(decipher, bciphertext, bciphertext.length, bnonce, bpublicKey, bprivateKey);
         try{

--- a/android/src/main/java/com/sodium/SodiumModule.java
+++ b/android/src/main/java/com/sodium/SodiumModule.java
@@ -84,7 +84,7 @@ public class SodiumModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void randomebytes(int length, Promise promise) {
+    public void randombytes(int length, Promise promise) {
         byte[] buffer = new byte[length];
         sodium().randombytes(buffer, length);
         promise.resolve(toString(buffer));

--- a/src/sodium.js
+++ b/src/sodium.js
@@ -17,10 +17,10 @@ let SodiumAPI = {
     CRYPTO_AUTH_BYTES: Sodium.CRYPTO_AUTH_BYTES,
     CRYPTO_AUTH_KEYBYTES: Sodium.CRYPTO_AUTH_KEYBYTES,
     
-    randomebytes: async(length :int) :string => {
+    randombytes: async(length :int) :string => {
         try {
-            var randomebytes = await Sodium.randomebytes(length)
-            return randomebytes
+            var randombytes = await Sodium.randombytes(length)
+            return randombytes
         } catch (error) {
             return error
         }


### PR DESCRIPTION
To be cross-compatible, the nonce should be seen as hex string. This PR fixes this issue. It also removes the extra **e** from `randomebytes` across the project.